### PR TITLE
Fix broken author link on DiffSkill page

### DIFF
--- a/diffskill/index.html
+++ b/diffskill/index.html
@@ -29,7 +29,7 @@
     <!--            <p class="abstract">An interpretable, data-efficient, and scalable neural scene representation.</p>-->
     <hr>
     <p class="authors">
-        <a href="hhttps://xingyu-lin.github.io/"> Xingyu Lin</a>,
+        <a href="https://xingyu-lin.github.io/"> Xingyu Lin</a>,
         <a href="https://sites.google.com/view/zhiao-huang"> Zhiao Huang</a>,
         <a href="http://people.csail.mit.edu/liyunzhu/"> Yunzhu Li</a>,
         <a href="http://web.mit.edu/cocosci/josh.html"> Joshua B. Tenenbaum</a>,


### PR DESCRIPTION
## Summary
- correct the malformed personal homepage link on the DiffSkill project page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862dedb32008330a8cca86414ba085c