### PR TITLE
Add distill style blog template

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -1,0 +1,46 @@
+body {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 40px 20px;
+  line-height: 1.6;
+  color: #333;
+}
+
+h1 {
+  font-size: 2.5em;
+  margin-bottom: 0.3em;
+}
+
+h2 {
+  font-size: 1.8em;
+  margin-top: 1.5em;
+}
+
+.date {
+  color: #777;
+  margin-bottom: 2em;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  margin: 1em auto;
+}
+
+pre {
+  background: #f5f5f5;
+  padding: 1em;
+  overflow-x: auto;
+}
+
+code {
+  font-family: 'Menlo', monospace;
+  background: #f5f5f5;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+section {
+  margin-bottom: 2em;
+}

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog</title>
+  <link rel="stylesheet" href="blog.css">
+</head>
+<body>
+  <h1>Blog</h1>
+  <ul>
+    <li><a href="sample-post.html">Sample Post</a> <span class="date">2024-05-08</span></li>
+  </ul>
+</body>
+</html>

--- a/blog/sample-post.html
+++ b/blog/sample-post.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sample Post</title>
+  <link rel="stylesheet" href="blog.css">
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+</head>
+<body>
+  <article>
+    <h1>Sample Post</h1>
+    <div class="date">Written on 2024-05-08</div>
+
+    <section>
+      <h2>Introduction</h2>
+      <p>This is a demonstration of a blog post using a distill-like format. The template supports equations like $e^{i\pi} + 1 = 0$ and inline code such as <code>print(&quot;hello&quot;)</code>.</p>
+    </section>
+
+    <section>
+      <h2>Code Example</h2>
+      <pre><code class="language-python">def hello(name):
+    print(f"Hello, {name}")
+</code></pre>
+    </section>
+
+    <section>
+      <h2>Equation</h2>
+      <p>We can write equations using LaTeX syntax:</p>
+      <p>$$
+      \nabla \cdot \mathbf{E} = \frac{\rho}{\varepsilon_0}
+      $$</p>
+    </section>
+
+    <section>
+      <h2>Image</h2>
+      <p>Images are centered and scaled:</p>
+      <img src="../img/profile.png" alt="Sample image">
+    </section>
+  </article>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `blog` folder with distill-like layout
- add template with sections, equation support via MathJax, code highlighting and images
- include sample blog post demonstrating the features

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862e19b85dc8330a70a63a6346b2750