### PR TITLE
Apply grayscale styling to blog pages

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,22 +1,52 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <script src="https://distill.pub/template.v2.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Blog</title>
-  <link rel="stylesheet" href="blog.css">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Blog - Xingyu Lin</title>
+    <link href="../vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../css/font-1.css" rel="stylesheet" type="text/css">
+    <link href="../vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+    <link href='https://fonts.googleapis.com/css?family=Cabin:700' rel='stylesheet' type='text/css'>
+    <link href="../css/grayscale.css" rel="stylesheet">
+    <link rel="stylesheet" href="blog.css">
 </head>
-<body>
-  <distill-header></distill-header>
-  <d-title>
-    <h1>Blog</h1>
-  </d-title>
-  <d-article>
+<body id="page-top">
+<nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
+    <div class="container">
+        <a class="navbar-brand" href="../#page-top">Xingyu Lin</a>
+        <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+            Menu
+            <i class="fa fa-bars"></i>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarResponsive">
+            <ul class="navbar-nav ml-auto">
+                <li class="nav-item">
+                    <a class="nav-link js-scroll-trigger" href="../#page-top">Home</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link js-scroll-trigger" href="../#pub">Publication</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link js-scroll-trigger" href="../#contact">Contact</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./">Blog</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div style="height:80px;">&nbsp;</div>
+<section class="container">
+    <h1 class="mt-4">Blog</h1>
     <ul class="post-list">
-      <li><a href="sample-post.html">Sample Post</a> <span class="date">2024-05-08</span></li>
+        <li><a href="sample-post.html">Sample Post</a> <span class="date">2024-05-08</span></li>
     </ul>
-  </d-article>
-  <distill-footer></distill-footer>
+</section>
+<script src="../vendor/jquery/jquery.min.js"></script>
+<script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
 </body>
 </html>

--- a/blog/sample-post.html
+++ b/blog/sample-post.html
@@ -1,50 +1,76 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <script src="https://distill.pub/template.v2.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Sample Post</title>
-  <link rel="stylesheet" href="blog.css">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Sample Post - Xingyu Lin</title>
+    <script src="https://distill.pub/template.v2.js"></script>
+    <link href="../vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../css/font-1.css" rel="stylesheet" type="text/css">
+    <link href="../vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+    <link href='https://fonts.googleapis.com/css?family=Cabin:700' rel='stylesheet' type='text/css'>
+    <link href="../css/grayscale.css" rel="stylesheet">
+    <link rel="stylesheet" href="blog.css">
 </head>
-<body>
-  <d-front-matter>
-    <script type="text/json" id="distill-front-matter">
-    {
-      "title": "Sample Post",
-      "published": "2024-05-08",
-      "authors": [{"author": "Xingyu Lin"}]
-    }
-    </script>
-  </d-front-matter>
-  <d-title>
-    <h1>Sample Post</h1>
-  </d-title>
-  <d-byline></d-byline>
-  <d-article>
-    <section>
-      <h2>Introduction</h2>
-      <p>This is a demonstration of a blog post using a distill-like format. The template supports equations like <d-math>e^{i\pi} + 1 = 0</d-math> and inline code such as <d-code language="python">print("hello")</d-code>.</p>
-    </section>
-    <section>
-      <h2>Code Example</h2>
-      <d-code block language="python">def hello(name):
+<body id="page-top">
+<nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
+    <div class="container">
+        <a class="navbar-brand" href="../#page-top">Xingyu Lin</a>
+        <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+            Menu
+            <i class="fa fa-bars"></i>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarResponsive">
+            <ul class="navbar-nav ml-auto">
+                <li class="nav-item"><a class="nav-link js-scroll-trigger" href="../#page-top">Home</a></li>
+                <li class="nav-item"><a class="nav-link js-scroll-trigger" href="../#pub">Publication</a></li>
+                <li class="nav-item"><a class="nav-link js-scroll-trigger" href="../#contact">Contact</a></li>
+                <li class="nav-item"><a class="nav-link" href="./">Blog</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div style="height:80px;">&nbsp;</div>
+<d-front-matter>
+<script type="text/json" id="distill-front-matter">
+{
+  "title": "Sample Post",
+  "published": "2024-05-08",
+  "authors": [{"author": "Xingyu Lin"}]
+}
+</script>
+</d-front-matter>
+<d-title>
+  <h1>Sample Post</h1>
+</d-title>
+<d-byline></d-byline>
+<d-article class="container">
+  <section>
+    <h2>Introduction</h2>
+    <p>This is a demonstration of a blog post using a distill-like format. The template supports equations like <d-math>e^{i\pi} + 1 = 0</d-math> and inline code such as <d-code language="python">print("hello")</d-code>.</p>
+  </section>
+  <section>
+    <h2>Code Example</h2>
+    <d-code block language="python">def hello(name):
     print(f"Hello, {name}")
 </d-code>
-    </section>
-    <section>
-      <h2>Equation</h2>
-      <p>We can write equations using LaTeX syntax:</p>
-      <d-math block>
-        \nabla \cdot \mathbf{E} = \frac{\rho}{\varepsilon_0}
-      </d-math>
-    </section>
-    <section>
-      <h2>Image</h2>
-      <p>Images are centered and scaled:</p>
-      <figure><img src="../img/profile.png" alt="Sample image"></figure>
-    </section>
-  </d-article>
-  <distill-footer></distill-footer>
+  </section>
+  <section>
+    <h2>Equation</h2>
+    <p>We can write equations using LaTeX syntax:</p>
+    <d-math block>
+      \nabla \cdot \mathbf{E} = \frac{\rho}{\varepsilon_0}
+    </d-math>
+  </section>
+  <section>
+    <h2>Image</h2>
+    <p>Images are centered and scaled:</p>
+    <figure><img src="../img/profile.png" alt="Sample image"></figure>
+  </section>
+</d-article>
+<script src="../vendor/jquery/jquery.min.js"></script>
+<script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update blog index to use the grayscale navbar
- convert sample post to grayscale template and retain Distill formatting

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862fc5201c083309356c83bc2303388